### PR TITLE
refactor: eliminate hardcoded model names, use model-registry as single source of truth

### DIFF
--- a/src/application/config/HybridConfigLoader.ts
+++ b/src/application/config/HybridConfigLoader.ts
@@ -15,6 +15,7 @@ import { NodeFileSystem } from '../../infrastructure/filesystem/node-filesystem.
 import { NodeFileWriter } from '../../infrastructure/filesystem/NodeFileWriter.js';
 import { YamlParser } from '../../infrastructure/parsers/YamlParser.js';
 import { createConsoleLogger } from '../../infrastructure/logging/logger.js';
+import { getDefaultModelId } from '../../config/model-registry.js';
 
 const logger = createConsoleLogger('info');
 
@@ -49,7 +50,7 @@ export function convertToResolvedConfig(hybridConfig: HybridConfig): any {
     chunkSize: hybridConfig.user.performance?.chunkSize || hybridConfig.system.model?.chunkSize || 1000,
     overlap: hybridConfig.user.performance?.overlap || hybridConfig.system.model?.overlap || 10,
     batchSize: hybridConfig.user.performance?.batchSize || hybridConfig.system.model?.batchSize || 32,
-    modelName: hybridConfig.user.model?.name || hybridConfig.system.model?.name || 'all-minilm',
+    modelName: hybridConfig.user.model?.name || hybridConfig.system.model?.name || getDefaultModelId(),
     maxConcurrentOperations: hybridConfig.user.performance?.maxConcurrentOperations || hybridConfig.system.model?.maxConcurrentOperations || 14,
     timeoutMs: hybridConfig.system.model?.timeoutMs || 30000,
     

--- a/src/config/registry.ts
+++ b/src/config/registry.ts
@@ -8,6 +8,7 @@
 
 import { ValidationRule, VALIDATION_RULES } from './schema.js';
 import { createConsoleLogger } from '../infrastructure/logging/logger.js';
+import { getSupportedGpuModelIds, getSupportedCpuModelIds } from './model-registry.js';
 
 const logger = createConsoleLogger('warn');
 
@@ -364,7 +365,16 @@ export class ConfigurationRegistry {
         const { getDefaultModelId } = require('./model-registry.js');
         return getDefaultModelId();
       },
-      examples: ['gpu:bge-m3', 'cpu:xenova-multilingual-e5-small', 'cpu:xenova-multilingual-e5-large'],
+      examples: (() => {
+        // Dynamically generate examples from model registry (single source of truth)
+        const gpuModels = getSupportedGpuModelIds();
+        const cpuModels = getSupportedCpuModelIds();
+        return [
+          gpuModels[0],  // First GPU model
+          cpuModels[0],  // First CPU model
+          cpuModels[1]   // Second CPU model (if available)
+        ].filter(Boolean);
+      })(),
       category: 'processing',
       tags: ['embedding', 'model', 'quality'],
       envVar: 'FOLDER_MCP_PROCESSING_MODEL_NAME',

--- a/src/daemon/services/model-cache-checker.ts
+++ b/src/daemon/services/model-cache-checker.ts
@@ -8,7 +8,7 @@
 import { CuratedModelInfo, ModelCheckStatus } from '../models/fmdm.js';
 import { ILoggingService } from '../../di/interfaces.js';
 import { join } from 'path';
-import { getSupportedGpuModelIds, getModelById } from '../../config/model-registry.js';
+import { getSupportedGpuModelIds, getSupportedCpuModelIds, getModelById } from '../../config/model-registry.js';
 import { ONNXDownloader } from '../../infrastructure/embeddings/onnx/onnx-downloader.js';
 import { MachineCapabilitiesDetector } from '../../domain/models/machine-capabilities.js';
 
@@ -233,13 +233,10 @@ export class ModelCacheChecker {
   }
 
   /**
-   * Get curated CPU model IDs
+   * Get curated CPU model IDs from model registry (single source of truth)
    */
   private getCuratedCPUModelIds(): string[] {
-    return [
-      'cpu:xenova-multilingual-e5-small',
-      'cpu:xenova-multilingual-e5-large'
-    ];
+    return getSupportedCpuModelIds();
   }
 
   /**

--- a/src/interfaces/tui-ink/components/AutoCompletionHandler.tsx
+++ b/src/interfaces/tui-ink/components/AutoCompletionHandler.tsx
@@ -4,6 +4,7 @@ import { existsSync, statSync } from 'fs';
 import { getContainer } from '../../../di/container';
 import { CONFIG_SERVICE_TOKENS } from '../../../config/di-setup';
 import { ConfigurationComponent } from '../../../config/ConfigurationComponent';
+import { getDefaultModelId } from '../../../config/model-registry.js';
 
 interface AutoCompletionHandlerProps {
     cliDir?: string | null | undefined;
@@ -82,7 +83,7 @@ export const AutoCompletionHandler: React.FC<AutoCompletionHandlerProps> = ({
                 setDirError('Failed to load directory information');
                 setModelError('Failed to load model information');
                 setAutoCompletedDir(process.cwd());
-                setAutoCompletedModel('cpu:xenova-multilingual-e5-small');
+                setAutoCompletedModel(getDefaultModelId());
                 setLoading(false);
             }
         };


### PR DESCRIPTION
- Replace hardcoded CPU model IDs in model-cache-checker.ts with getSupportedCpuModelIds()
- Replace hardcoded default model 'all-minilm' in HybridConfigLoader.ts with getDefaultModelId()
- Replace hardcoded example models in registry.ts with dynamic generation from model registry
- Replace hardcoded fallback model in AutoCompletionHandler.tsx with getDefaultModelId()
- Refactor isPythonModel() in windows-performance-service.ts to use isGpuRequired() with intelligent fallback

All production code now sources model information from src/config/curated-models.json via model-registry.ts API.

Changes:
- src/daemon/services/model-cache-checker.ts
- src/application/config/HybridConfigLoader.ts
- src/config/registry.ts
- src/interfaces/tui-ink/components/AutoCompletionHandler.tsx
- src/daemon/services/windows-performance-service.ts

Benefits:
- Single source of truth maintained
- Automatic sync when models added/removed in curated-models.json
- Improved maintainability and consistency
- Type-safe model access

Note: Ollama detector excluded as requested (future code not in use)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored model configuration to use a centralized registry system, replacing hardcoded model identifiers with dynamic lookups for improved maintainability.
  * Enhanced model detection mechanisms with registry-based GPU checks and refined Python model pattern recognition for better system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->